### PR TITLE
modified the the gitignore to add target folder from maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 # Ignore compiled Java classes
 *.class
-
+/target/
+/out/
 
 # IntelliJ IDEA
-.idea/
+/.idea/
 *.iml
-out/
-

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,5 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Environment-dependent path to Maven home directory
-/mavenHomeManager.xml


### PR DESCRIPTION
mvn package and other commands compiles the .java into a target folder, not out. Added to the gitignore to prevent them being added unnecessarily to the repo