### PR TITLE
Maven dependencies Upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.3.232</version>
+            <version>2.4.240</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20231013</version>
+            <version>20250517</version>
         </dependency>
 
         <!-- SLF4J API - logging framework used by google ADK (Optional) -->


### PR DESCRIPTION
all dependencies updated to latest stable versions. Logging framework must remain out of date to match the version Google ADK is running